### PR TITLE
add another example for iter, compare to Python generator expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ for x in iter {
 // Print (0, 'a') (0, 'b') (1, 'a') (1, 'b')
 ```
 
+You can also have Python like generator expressions:
+
+```Python
+# Generator expression in Python:
+
+values = [6, 2, 9, 4, -1, 33, 87, 23]
+result = (x*x for x in values if x < 10)
+```
+
+```Rust
+// "Generator" expression in Rust (also in just one line):
+
+let values = vec![6, 2, 9, 4, -1, 33, 87, 23];
+let result = iter!{let x <- values; if x < 10; x*x};
+```
+
+Note that the order is reversed:
+- first let binding
+- then the guard
+- and the result expression as last item
+
+The result is of type FlatMap and also lazy, like Pythons generator expressions.
+
+
 ### Option
 ```rust
 #[macro_use]


### PR DESCRIPTION
I've added another example for _iter!_ to show how easy it is to use. It's quite similar to Pythons generator expressions which I really like.